### PR TITLE
Add pv command in the import-data.sh to see the progress

### DIFF
--- a/import-data.sh
+++ b/import-data.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+apt-get install pv
+
 SOURCES=(`echo $IMPORT_SOURCES | tr -s '|' ' '`)
 
 for SOURCE in ${SOURCES[@]}
@@ -11,8 +13,14 @@ do
   TARGET_PASSWORD=${SOURCE_TOKENS[3]}
   TARGET_DATABASE=${SOURCE_TOKENS[4]}
 
+  echo $TARGET_DATABASE
+  GET_SIZE="SELECT table_schema AS \`database\`, ROUND(SUM(data_length + index_length) / 1024 / 1024, 2) AS \`size\` FROM information_schema.TABLES GROUP BY table_schema HAVING \`database\` = '${TARGET_DATABASE}';"
+
+  TARGET_SIZE=$(mysql -s -N -u ${TARGET_USERNAME} -h ${TARGET_HOST} -p${TARGET_PASSWORD} -e "${GET_SIZE}" | awk -F '\t' {'print $2'} )
+  echo "target size for ${TARGET_DATABASE} = ${TARGET_SIZE%.*}M"
+
   DUMP_FILE=/tmp/${TARGET_HOST}_${TARGET_DATABASE}.sql
-  mysqldump -h $TARGET_HOST -u $TARGET_USERNAME -p$TARGET_PASSWORD $TARGET_DATABASE > $DUMP_FILE
+  mysqldump -h $TARGET_HOST -u $TARGET_USERNAME -p$TARGET_PASSWORD $TARGET_DATABASE | pv -s ${TARGET_SIZE%.*}M > $DUMP_FILE
   if [ $? -ne 0 ]; then
     echo "Failed to dump $TARGET_HOST" 1>&2
     exit 1
@@ -29,6 +37,4 @@ do
     echo "Failed to import data $TARGET_DATABASE" 1>&2
     exit 1
   fi
-
 done
-


### PR DESCRIPTION
大きめのデータベースからdumpを行う場合の進捗を見たかったので `pv` コマンドで `mysqldump` の進捗を見れるようにしました。

動作に関してはほとんどここに書いてあることと同じです。

* [is there a way to have mysqldump progress bar which shows the users the status of their backups?](http://stackoverflow.com/questions/4852933/is-there-a-way-to-have-mysqldump-progress-bar-which-shows-the-users-the-status-o)

`information_schema.TABLES` 内の `data_length` と `index_length` を合計したものをメガバイト単位に直して`pv`コマンドに渡しています。



よろしければご利用ください。